### PR TITLE
Add CC to license file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,12 @@
+The software provided in this example, both the code lines demonstrated in the
+[Jupyter Notebook (archived as a webpage)](README.md) and in additional helper files,
+is licensed under the Apache License, Version 2.0 (see below).
+
+The [Jupyter Notebook (archived as a webpage)](README.md) itself is licensed under a
+[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-nc-sa/4.0)
+
+![Creative Commons License](https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png)
+
                              Apache License
                          Version 2.0, January 2004
                       http://www.apache.org/licenses/


### PR DESCRIPTION
@silviacorbellaro, this one is different from the others because the JN has been archived in the README file in webpage format so I added "(archived as a webpage)" for clarity.  