### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk>=3.3.0
-jupyter
+bokeh~=2.0
+networkx~=2.0
+numpy~=1.0
 matplotlib~=3.0
-bokeh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+dwave-ocean-sdk>=3.3.0
+jupyter
+matplotlib~=3.0
+bokeh


### PR DESCRIPTION
Motivation: document requirements of the remaining working code (`helpers`), so they can be installed on demand, and we don't need to have them (i.e. `bokeh`) preinstalled in our LeapIDE image.